### PR TITLE
adds mitigation for small edge case when a user exits and then re-enters

### DIFF
--- a/src/contracts/MerklePools.sol
+++ b/src/contracts/MerklePools.sol
@@ -264,18 +264,19 @@ contract MerklePools is MerklePoolsStorage, ReentrancyGuardUpgradeable {
         MerkleStake.Data storage forfeitStake = stakes[forfeitAddress][_poolId];
         forfeitStake.update(pool, poolContext);
 
-        forfeitStake.totalUnclaimed += stake.totalUnclaimed;
+        forfeitStake.totalUnrealized += stake.totalUnrealized;
         
-        // we need to zero our their total unclaimed and also ensure that they are unable to just
-        // re-enter and then claim using a stale merkle proof as their unclaimed increments again
-        // over time.  By adding their unclaimed to their totalClaimed, we ensure that any 
+        // we need to zero our their total unrealized and also ensure that they are unable to just
+        // re-enter and then claim using a stale merkle proof as their unrealized increments again
+        // over time.  By adding their unrealized to their totalRealized, we ensure that any 
         // existing merkle claim is now un-claimable by them until we generate a new merkle claim
-        // that accounts for these values.  This means that the sum of all stakes.totalClaimedTIC
-        // is not accurate and that we also need to check in the UI to not end up with negative
+        // that accounts for these values.  This means that the sum of all stakes.totalRealizedTIC
+        // is not accurate in terms of tic claimed 
+        // and that we also need to check in the UI to not end up with negative
         // claimable values.  The off chain accounting needs to consider this as well if a 
         // user does re-enter wit the same address in the future. 
-        stake.totalClaimedTIC += stake.totalUnclaimed; 
-        stake.totalUnclaimed = 0;
+        stake.totalRealizedTIC += stake.totalUnrealized; 
+        stake.totalUnrealized = 0;
         
 
         IERC20Upgradeable(pool.token).safeTransfer(msg.sender, withdrawAmount);
@@ -405,8 +406,8 @@ contract MerklePools is MerklePoolsStorage, ReentrancyGuardUpgradeable {
         );
 
         MerkleStake.Data storage stake = stakes[msg.sender][_poolId];
-        uint256 alreadyClaimedLPAmount = stake.totalClaimedLP;
-        uint256 alreadyClaimedTICAmount = stake.totalClaimedTIC;
+        uint256 alreadyClaimedLPAmount = stake.totalRealizedLP;
+        uint256 alreadyClaimedTICAmount = stake.totalRealizedTIC;
 
         require(
             _totalLPTokenAmount > alreadyClaimedLPAmount &&
@@ -432,15 +433,15 @@ contract MerklePools is MerklePoolsStorage, ReentrancyGuardUpgradeable {
         }
 
         require(
-            ticTokenAmountToBeClaimed <= stake.totalUnclaimed,
+            ticTokenAmountToBeClaimed <= stake.totalUnrealized,
             "MerklePools: INVALID_UNCLAIMED_AMOUNT"
         );
 
-        stake.totalClaimedLP = _totalLPTokenAmount;
-        stake.totalClaimedTIC = _totalTICAmount;
+        stake.totalRealizedLP = _totalLPTokenAmount;
+        stake.totalRealizedTIC = _totalTICAmount;
 
         unchecked {
-            stake.totalUnclaimed -= ticTokenAmountToBeClaimed;
+            stake.totalUnrealized -= ticTokenAmountToBeClaimed;
         }
         pool.totalUnclaimedTIC -= ticTokenAmountToBeClaimed;
         pool.totalUnclaimedTICInLP -= ticTokenAmountToBeClaimed;

--- a/src/contracts/MerklePools.sol
+++ b/src/contracts/MerklePools.sol
@@ -267,7 +267,7 @@ contract MerklePools is MerklePoolsStorage, ReentrancyGuardUpgradeable {
         forfeitStake.totalUnclaimed += stake.totalUnclaimed;
         
         // we need to zero our their total unclaimed and also ensure that they are unable to just
-        // re-enter and then use a stale merkle proof and their unclaimed increments again
+        // re-enter and then claim using a stale merkle proof as their unclaimed increments again
         // over time.  By adding their unclaimed to their totalClaimed, we ensure that any 
         // existing merkle claim is now un-claimable by them until we generate a new merkle claim
         // that accounts for these values.  This means that the sum of all stakes.totalClaimedTIC

--- a/src/libraries/merklePools/MerkleStake.sol
+++ b/src/libraries/merklePools/MerkleStake.sol
@@ -14,9 +14,9 @@ library MerkleStake {
 
     struct Data {
         uint256 totalDeposited;
-        uint256 totalUnclaimed;
-        uint256 totalClaimedTIC;
-        uint256 totalClaimedLP;
+        uint256 totalUnrealized;
+        uint256 totalRealizedTIC;
+        uint256 totalRealizedLP;
         FixedPointMath.FixedDecimal lastAccumulatedWeight;
     }
 
@@ -25,7 +25,7 @@ library MerkleStake {
         MerklePool.Data storage _pool,
         MerklePool.Context storage _ctx
     ) internal {
-        _self.totalUnclaimed = _self.getUpdatedTotalUnclaimed(_pool, _ctx);
+        _self.totalUnrealized = _self.getUpdatedTotalUnclaimed(_pool, _ctx);
         _self.lastAccumulatedWeight = _pool.getUpdatedAccumulatedRewardWeight(
             _ctx
         );
@@ -42,7 +42,7 @@ library MerkleStake {
             _self.lastAccumulatedWeight;
 
         if (currentAccumulatedWeight.cmp(lastAccumulatedWeight) == 0) {
-            return _self.totalUnclaimed;
+            return _self.totalUnrealized;
         }
 
         uint256 amountToDistribute =
@@ -51,6 +51,6 @@ library MerkleStake {
                 .mul(_self.totalDeposited)
                 .decode();
 
-        return _self.totalUnclaimed + amountToDistribute;
+        return _self.totalUnrealized + amountToDistribute;
     }
 }


### PR DESCRIPTION
User 1 stakes and we disperse rewards and the node looks like -

Merkle node 1
_totalLPTokenAmount = 5
_totalTICAmount = 50

The user exits for some reason before we publish or before they claim, and cannot claim anything now and forfeits their rewards to forfeit address.

Time passes and ....

They re-enter and they could theoretically use the old proof to claim as their stake.totalUnclaimed increases over time. 

This is problematic since those LP tokens should belong to the forfeit address.

See the comment in the diff to understand why this approach works to fix the issue but with some small side affects. 